### PR TITLE
Fix typo in Bricks example Velocity format

### DIFF
--- a/Bricks/example.vm
+++ b/Bricks/example.vm
@@ -1,4 +1,4 @@
-#set ( $sib = $_XPathTool.selectSingleNode($contentRoot, "/system-index-block) )
+#set ( $sib = $_XPathTool.selectSingleNode($contentRoot, "/system-index-block") )
 
 #set ( $bricks = $_XPathTool.selectNodes($sib, "system-page/system-data-structure/brick") )
 #macro ( useBricks $contentString )


### PR DESCRIPTION
Fixing a typo pointed out to us by a client (Bill White) that makes the example Velocity format in the Bricks site unsaveable.